### PR TITLE
Fix 404 Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Detecting text that was generated from large language models (e.g. GPT-2).
 
 
 webpage: [http://gltr.io](http://gltr.io)<br>
-online-demo: [http://gltr.io/dist/index.html](http://gltr.io/dist/index.html)<br>
+online-demo: [http://demo.gltr.io/client/index.html](http://demo.gltr.io/client/index.html)<br>
 paper: [https://arxiv.org/abs/1906.04043](https://arxiv.org/abs/1906.04043) 
 
 A project by Hendrik Strobelt, Sebastian Gehrmann, Alexander M. Rush.


### PR DESCRIPTION
The current link results in a 404 page not found.